### PR TITLE
Update buttons.bootstrap5.js - Remove explicit bs style for button.

### DIFF
--- a/js/buttons.bootstrap5.js
+++ b/js/buttons.bootstrap5.js
@@ -59,7 +59,7 @@ $.extend(true, DataTable.Buttons.defaults, {
 			className: 'dt-buttons btn-group flex-wrap'
 		},
 		button: {
-			className: 'btn btn-secondary',
+			className: 'btn',
 			active: 'active',
 			dropHtml: '',
 			dropClass: 'dropdown-toggle'


### PR DESCRIPTION
Removed btn-secondary which is an explicit style that cannot be modified by the user of this plugin.